### PR TITLE
feat-mdx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,8 +2973,7 @@ dependencies = [
 [[package]]
 name = "mdxjs"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4bbd566f0dd80e0701ef5ca305e4404805eb37b95a6246ac1605acb71a6e9b"
+source = "git+https://github.com/kwonoj/mdxjs-rs?rev=3536b8648e118047f916b20c0e968ac15d8c1e76#3536b8648e118047f916b20c0e968ac15d8c1e76"
 dependencies = [
  "markdown",
  "serde",
@@ -7102,6 +7101,7 @@ dependencies = [
  "turbopack-ecmascript",
  "turbopack-env",
  "turbopack-json",
+ "turbopack-mdx",
  "turbopack-static",
 ]
 
@@ -7266,6 +7266,23 @@ dependencies = [
  "turbo-tasks-fs",
  "turbopack-core",
  "turbopack-ecmascript",
+]
+
+[[package]]
+name = "turbopack-mdx"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mdxjs",
+ "serde",
+ "serde_json",
+ "swc_core 0.45.4",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-fs",
+ "turbopack-core",
+ "turbopack-ecmascript",
+ "turbopack-swc-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/turbopack-dev-server",
   "crates/turbopack-ecmascript",
   "crates/turbopack-env",
+  "crates/turbopack-mdx",
   "crates/turbopack-node",
   "crates/turbopack-json",
   "crates/turbopack-static",
@@ -92,6 +93,6 @@ swc_emotion = { version = "0.28.4" }
 styled_jsx = { version = "0.29.8" }
 styled_components = { version = "0.52.8" }
 modularize_imports = { version = "0.25.8" }
-mdxjs = { version = "0.1.3" }
+mdxjs = { git = "https://github.com/kwonoj/mdxjs-rs", rev = "3536b8648e118047f916b20c0e968ac15d8c1e76" }
 next-dev = { path = "crates/next-dev", version = "0.1.0" }
 node-file-trace = { path = "crates/node-file-trace", version = "0.1.0" }

--- a/crates/next-core/src/server_rendered_source.rs
+++ b/crates/next-core/src/server_rendered_source.rs
@@ -242,7 +242,7 @@ async fn create_server_rendered_source_for_directory(
                         match extension {
                             // pageExtensions option from next.js
                             // defaults: https://github.com/vercel/next.js/blob/611e13f5159457fedf96d850845650616a1f75dd/packages/next/server/config-shared.ts#L499
-                            "js" | "ts" | "jsx" | "tsx" => {
+                            "js" | "ts" | "jsx" | "tsx" | "mdx" => {
                                 let (dev_server_path, intermediate_output_path, specificity) =
                                     if basename == "index" {
                                         (

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -27,9 +27,12 @@ use chunk::{
     EcmascriptChunkItem, EcmascriptChunkItemVc, EcmascriptChunkPlaceablesVc, EcmascriptChunkVc,
 };
 use code_gen::CodeGenerateableVc;
+pub use parse::hash_file_path;
 use parse::{parse, ParseResult, ParseResultSourceMap};
-use path_visitor::ApplyVisitors;
-use references::AnalyzeEcmascriptModuleResult;
+pub use path_visitor::ApplyVisitors;
+pub use references::{
+    analyze_ecmascript_module, AnalyzeEcmascriptModuleResult, AnalyzeEcmascriptModuleResultVc,
+};
 use swc_core::{
     common::GLOBALS,
     ecma::{
@@ -37,7 +40,7 @@ use swc_core::{
         visit::{VisitMutWith, VisitMutWithPath},
     },
 };
-pub use transform::{EcmascriptInputTransform, EcmascriptInputTransformsVc};
+pub use transform::{EcmascriptInputTransform, EcmascriptInputTransformsVc, TransformContext};
 use turbo_tasks::{primitives::StringVc, TryJoinIterExt, Value, ValueToString, ValueToStringVc};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
@@ -49,17 +52,11 @@ use turbopack_core::{
     resolve::origin::{ResolveOrigin, ResolveOriginVc},
 };
 
-use self::{
-    chunk::{
-        EcmascriptChunkItemContent, EcmascriptChunkItemContentVc, EcmascriptChunkItemOptions,
-        EcmascriptExportsVc,
-    },
-    references::AnalyzeEcmascriptModuleResultVc,
+use self::chunk::{
+    EcmascriptChunkItemContent, EcmascriptChunkItemContentVc, EcmascriptChunkItemOptions,
+    EcmascriptExportsVc,
 };
-use crate::{
-    chunk::{EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc},
-    references::analyze_ecmascript_module,
-};
+use crate::chunk::{EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc};
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -297,7 +297,7 @@ async fn parse_content(
 }
 
 #[turbo_tasks::function]
-async fn hash_file_path(file_path_vc: FileSystemPathVc) -> Result<U64Vc> {
+pub async fn hash_file_path(file_path_vc: FileSystemPathVc) -> Result<U64Vc> {
     let file_path = &*file_path_vc.await?;
     let mut hasher = Xxh3Hash64Hasher::new();
     hasher.write_bytes(file_path.file_name().as_bytes());

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -164,7 +164,7 @@ impl Default for AnalyzeEcmascriptModuleResultBuilder {
 }
 
 #[turbo_tasks::function]
-pub(crate) async fn analyze_ecmascript_module(
+pub async fn analyze_ecmascript_module(
     source: AssetVc,
     origin: ResolveOriginVc,
     ty: Value<EcmascriptModuleAssetType>,

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -189,6 +189,13 @@ impl EcmascriptInputTransform {
 
                 program.visit_mut_with(&mut next_font);
             }
+            /*EcmascriptInputTransform::Mdx => {
+                [TODOMdx]
+                // in case of mdx, most of processings are pre-process
+                // that converts mdx into SWC's AST, then rest of
+                // transforms should be existing EcmascriptInputTransform.
+                // Do we even need this?
+            }*/
             EcmascriptInputTransform::Custom => todo!(),
         }
         Ok(())

--- a/crates/turbopack-mdx/Cargo.toml
+++ b/crates/turbopack-mdx/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "turbopack-mdx"
+version = "0.1.0"
+description = "TBD"
+license = "MPL-2.0"
+edition = "2021"
+autobenches = false
+
+[lib]
+bench = false
+
+[dependencies]
+anyhow = "1.0.47"
+
+turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-fs = { path = "../turbo-tasks-fs" }
+turbopack-core = { path = "../turbopack-core" }
+turbopack-ecmascript = { path = "../turbopack-ecmascript" }
+turbopack-swc-utils = { path = "../turbopack-swc-utils" }
+
+serde = "1.0.136"
+serde_json = "1.0.81"
+
+mdxjs = { workspace = true }
+swc_core = { workspace = true }
+
+[build-dependencies]
+turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-mdx/build.rs
+++ b/crates/turbopack-mdx/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/crates/turbopack-mdx/src/chunk/mod.rs
+++ b/crates/turbopack-mdx/src/chunk/mod.rs
@@ -1,0 +1,8 @@
+#[turbo_tasks::value(shared)]
+#[derive(Default)]
+pub struct MdxChunkItemContent {
+    //pub inner_code: Rope,
+    //pub source_map: Option<ParseResultSourceMapVc>,
+    //pub options: EcmascriptChunkItemOptions,
+    pub placeholder_for_future_extensions: (),
+}

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -1,0 +1,355 @@
+#![feature(min_specialization)]
+#![feature(box_syntax)]
+
+use anyhow::{anyhow, Result};
+
+pub(crate) mod chunk;
+pub(crate) mod parse;
+pub(crate) mod transform;
+
+use mdxjs::compile;
+/*
+use parse::{parse, ParseResult};
+use swc_core::{
+    common::{FilePathMapping, SourceMap, GLOBALS},
+    ecma::{
+        codegen::{text_writer::JsWriter, Emitter},
+        visit::{VisitMutWith, VisitMutWithPath},
+    },
+}; */
+use turbo_tasks::{primitives::StringVc, Value, ValueToString, ValueToStringVc};
+use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPathVc};
+use turbopack_core::{
+    asset::{Asset, AssetContent, AssetContentVc, AssetVc},
+    chunk::{ChunkItem, ChunkItemVc, ChunkVc, ChunkableAsset, ChunkableAssetVc, ChunkingContextVc},
+    context::AssetContextVc,
+    reference::AssetReferencesVc,
+    resolve::origin::{ResolveOrigin, ResolveOriginVc},
+    virtual_asset::VirtualAssetVc,
+};
+use turbopack_ecmascript::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContentVc, EcmascriptChunkItemVc,
+        EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc, EcmascriptChunkVc,
+    },
+    AnalyzeEcmascriptModuleResultVc, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
+    EcmascriptModuleAssetVc,
+};
+
+#[turbo_tasks::value]
+#[derive(Clone, Copy)]
+pub struct MdxModuleAsset {
+    pub source: AssetVc,
+    pub context: AssetContextVc,
+    pub transforms: EcmascriptInputTransformsVc,
+}
+
+#[turbo_tasks::value_impl]
+impl MdxModuleAssetVc {
+    #[turbo_tasks::function]
+    pub fn new(
+        source: AssetVc,
+        context: AssetContextVc,
+        transforms: EcmascriptInputTransformsVc,
+    ) -> Self {
+        Self::cell(MdxModuleAsset {
+            source,
+            context,
+            transforms,
+        })
+    }
+
+    /// Perform analyze against mdx components.
+    /// MDX components should be treated as normal j|tsx components to analyze
+    /// its imports, only difference is it is not a valid ecmascript AST we
+    /// can't pass it forward directly. Internally creates an jsx from mdx
+    /// via mdxrs, then pass it through existing ecmascript analyzer.
+    #[turbo_tasks::function]
+    pub async fn analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        let this = self.await?;
+        let content = this.source.content();
+
+        if let AssetContent::File(file) = &*content.await? {
+            if let FileContent::Content(file) = &*file.await? {
+                let file_conent = file.content().to_str()?;
+                let mdx_jdx_component =
+                    compile(&file_conent, &Default::default()).map_err(|e| anyhow!("{}", e))?;
+
+                let result = Rope::from(mdx_jdx_component);
+                let file = File::from(result);
+                let source = VirtualAssetVc::new(this.source.path(), file.into());
+                // alternatively, could try to use analyze_ecmascript_module directly
+                let vc = EcmascriptModuleAssetVc::new(
+                    source.into(),
+                    this.context.into(),
+                    Value::new(EcmascriptModuleAssetType::Typescript),
+                    this.transforms,
+                    this.context.environment(),
+                );
+
+                Ok(vc.analyze())
+            } else {
+                Err(anyhow!("Not able to read mdx file content"))
+            }
+        } else {
+            Err(anyhow!("Unexpected mdx asset content"))
+        }
+    }
+
+    /*
+    pub async fn analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        let this = self.await?;
+        // Analyze import via `parsed` MDX input into swc ast -> str emitted
+        let parsed = parse(this.source, this.transforms).await?;
+        let p = this.source.path();
+
+        match &*parsed {
+            ParseResult::Ok { program, comments } => {
+                if let Program::Module(mut module) = program.clone() {
+                    let source = serialize(&mut module, None);
+                    let result = Rope::from(source);
+                    let file = File::from(result);
+                    let source = VirtualAssetVc::new(p, file.into());
+
+                    Ok(analyze_ecmascript_module(
+                        source.into(),
+                        self.as_resolve_origin(),
+                        Value::new(EcmascriptModuleAssetType::Typescript),
+                        this.transforms,
+                        this.context.environment(),
+                    ))
+                } else {
+                    anyhow::bail!("Parsed mdx cannot be non-module")
+                }
+            }
+            _ => anyhow::bail!("parse error"),
+        }
+    } */
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn path(&self) -> FileSystemPathVc {
+        self.source.path()
+    }
+
+    #[turbo_tasks::function]
+    fn content(&self) -> AssetContentVc {
+        self.source.content()
+    }
+
+    #[turbo_tasks::function]
+    async fn references(self_vc: MdxModuleAssetVc) -> Result<AssetReferencesVc> {
+        Ok(self_vc.analyze().await?.references)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableAsset for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn as_chunk(self_vc: MdxModuleAssetVc, context: ChunkingContextVc) -> ChunkVc {
+        EcmascriptChunkVc::new(context, self_vc.as_ecmascript_chunk_placeable()).into()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self_vc: MdxModuleAssetVc,
+        context: ChunkingContextVc,
+    ) -> EcmascriptChunkItemVc {
+        MdxChunkItemVc::cell(MdxChunkItem {
+            module: self_vc,
+            context,
+        })
+        .into()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ResolveOrigin for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn origin_path(&self) -> FileSystemPathVc {
+        self.source.path()
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> AssetContextVc {
+        self.context
+    }
+}
+
+#[turbo_tasks::value]
+struct MdxChunkItem {
+    module: MdxModuleAssetVc,
+    context: ChunkingContextVc,
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for MdxChunkItem {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(format!(
+            "{} (mdx)",
+            self.module.await?.source.path().to_string().await?
+        )))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for MdxChunkItem {
+    #[turbo_tasks::function]
+    fn references(&self) -> AssetReferencesVc {
+        self.module.references()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for MdxChunkItem {
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> ChunkingContextVc {
+        self.context
+    }
+
+    ///[TODOMdx]
+    /// Once we have mdx contents, we should treat it as j|tsx components and
+    /// apply all of the ecma transforms
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<EcmascriptChunkItemContentVc> {
+        let this = self.module.await?;
+        let content = this.source.content();
+
+        if let AssetContent::File(file) = &*content.await? {
+            if let FileContent::Content(file) = &*file.await? {
+                let file_conent = file.content().to_str()?;
+                let mdx_jdx_component =
+                    compile(&file_conent, &Default::default()).map_err(|e| anyhow!("{}", e))?;
+
+                let result = Rope::from(mdx_jdx_component);
+                let file = File::from(result);
+                let source = VirtualAssetVc::new(this.source.path(), file.into());
+                let vc = EcmascriptModuleAssetVc::new(
+                    source.into(),
+                    this.context.into(),
+                    Value::new(EcmascriptModuleAssetType::Typescript),
+                    this.transforms,
+                    this.context.environment(),
+                );
+
+                Ok(vc.as_chunk_item(self.context).content())
+            } else {
+                Err(anyhow!("Not able to read mdx file content"))
+            }
+        } else {
+            Err(anyhow!("Unexpected mdx asset content"))
+        }
+    }
+
+    /*
+    async fn content(&self) -> Result<EcmascriptChunkItemContentVc> {
+        let AnalyzeEcmascriptModuleResult {
+            references,
+            code_generation,
+            ..
+        } = &*self.module.analyze().await?;
+
+        let context = self.context;
+        let mut code_gens = Vec::new();
+        for r in references.await?.iter() {
+            if let Some(code_gen) = CodeGenerateableVc::resolve_from(r).await? {
+                code_gens.push(code_gen.code_generation(context));
+            }
+        }
+        for c in code_generation.await?.iter() {
+            let c = c.resolve().await?;
+            code_gens.push(c.code_generation(context));
+        }
+        // need to keep that around to allow references into that
+        let code_gens = code_gens.into_iter().try_join().await?;
+        let code_gens = code_gens.iter().map(|cg| &**cg).collect::<Vec<_>>();
+        // TOOD use interval tree with references into "code_gens"
+        let mut visitors = Vec::new();
+        let mut root_visitors = Vec::new();
+        for code_gen in code_gens {
+            for (path, visitor) in code_gen.visitors.iter() {
+                if path.is_empty() {
+                    root_visitors.push(&**visitor);
+                } else {
+                    visitors.push((path, &**visitor));
+                }
+            }
+        }
+
+        let module = self.module.await?;
+        let parsed = parse(module.source, module.transforms).await?;
+
+        if let ParseResult::Ok { program, comments } = &*parsed {
+            let mut program = program.clone();
+            let source_map = Arc::new(SourceMap::new(FilePathMapping::empty()));
+
+            GLOBALS.set(&Default::default(), || {
+                if !visitors.is_empty() {
+                    program.visit_mut_with_path(
+                        &mut ApplyVisitors::new(visitors),
+                        &mut Default::default(),
+                    );
+                }
+                for visitor in root_visitors {
+                    program.visit_mut_with(&mut visitor.create());
+                }
+                program.visit_mut_with(&mut swc_core::ecma::transforms::base::fixer::fixer(None));
+            });
+
+            let mut bytes: Vec<u8> = vec![];
+            let mut srcmap = vec![];
+            let mut emitter = Emitter {
+                cfg: swc_core::ecma::codegen::Config {
+                    ..Default::default()
+                },
+                cm: source_map.clone(),
+                comments: None,
+                wr: JsWriter::new(source_map.clone(), "\n", &mut bytes, Some(&mut srcmap)),
+            };
+
+            emitter.emit_program(&program)?;
+
+            //[TODOMdx]
+            //let srcmap = ParseResultSourceMap::new(source_map.clone(), srcmap).cell();
+
+            Ok(EcmascriptChunkItemContent {
+                inner_code: bytes.into(),
+                source_map: None, //Some(srcmap),
+                // [TodoMdx]
+                options: EcmascriptChunkItemOptions {
+                    // These things are not available in ESM
+                    module: true,
+                    exports: true,
+                    this: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .into())
+        } else {
+            Ok(EcmascriptChunkItemContent {
+                inner_code: format!(
+                    "const e = new Error(\"Could not parse module '{path}'\");\ne.code = \
+                     'MODULE_UNPARSEABLE';\nthrow e;",
+                    path = self.module.path().to_string().await?
+                )
+                .into(),
+                ..Default::default()
+            }
+            .into())
+        }
+    } */
+}
+
+pub fn register() {
+    turbo_tasks::register();
+    turbo_tasks_fs::register();
+    turbopack_core::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}

--- a/crates/turbopack-mdx/src/parse.rs
+++ b/crates/turbopack-mdx/src/parse.rs
@@ -1,0 +1,188 @@
+use std::{future::Future, sync::Arc};
+
+use anyhow::Result;
+use mdxjs::{interop_swc_ast, parse_hast_string, Location};
+use swc_core::{
+    base::SwcComments,
+    common::{
+        comments::Comments,
+        errors::{Handler, HANDLER},
+        Globals, Mark, SourceMap, GLOBALS,
+    },
+    ecma::{
+        ast::Program,
+        transforms::base::helpers::{Helpers, HELPERS},
+    },
+};
+use turbo_tasks::ValueToString;
+use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbopack_core::asset::{AssetContent, AssetVc};
+use turbopack_ecmascript::{
+    hash_file_path, utils::WrapFuture, EcmascriptInputTransform, EcmascriptInputTransformsVc,
+    TransformContext,
+};
+use turbopack_swc_utils::emitter::IssueEmitter;
+
+#[turbo_tasks::value(shared, serialization = "none", eq = "manual")]
+#[allow(clippy::large_enum_variant)]
+pub enum ParseResult {
+    Ok {
+        #[turbo_tasks(trace_ignore)]
+        program: Program,
+        #[turbo_tasks(debug_ignore, trace_ignore)]
+        comments: SwcComments,
+        // [TODOMdx]
+        //#[turbo_tasks(debug_ignore, trace_ignore)]
+        //eval_context: EvalContext,
+        //#[turbo_tasks(debug_ignore, trace_ignore)]
+        //globals: Globals,
+        //#[turbo_tasks(debug_ignore, trace_ignore)]
+        //source_map: Arc<SourceMap>,
+    },
+    Unparseable,
+    NotFound,
+}
+
+impl PartialEq for ParseResult {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Ok { .. }, Self::Ok { .. }) => false,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+async fn parse_content(
+    string: String,
+    fs_path: &FileSystemPath,
+    fs_path_str: &str,
+    file_path_hash: u128,
+    source: AssetVc,
+    transforms: &[EcmascriptInputTransform],
+) -> Result<ParseResultVc> {
+    let source_map: Arc<SourceMap> = Default::default();
+    let handler = Handler::with_emitter(
+        true,
+        false,
+        box IssueEmitter {
+            source,
+            source_map: source_map.clone(),
+            title: Some("Parsing mdx source code failed".to_string()),
+        },
+    );
+
+    //[TODOMdx]
+    let config = Default::default();
+
+    //[TODOMdx]: Do we need `SourceFile`?
+    let parsed_mdx = match parse_hast_string(&string, &config) {
+        Ok(hast_node) => hast_node,
+        Err(e) => {
+            // [TODOMdx]: mdxrs currently returns untyped string as error, need to convert it for diagnostics.emit()
+            println!("{:#?}", e);
+            // TODO report in in a stream
+            return Ok(ParseResult::Unparseable.into());
+        }
+    };
+
+    let location = Location::new(string.as_bytes());
+    // Note: this is not SWC's Program AST
+    let program = match interop_swc_ast(&parsed_mdx, &location, &config) {
+        Ok(program) => program,
+        Err(e) => {
+            // [TODOMdx]: mdxrs currently returns untyped string as error, need to convert it for diagnostics.emit()
+            println!("{:#?}", e);
+            // TODO report in in a stream
+            return Ok(ParseResult::Unparseable.into());
+        }
+    };
+
+    let globals = Globals::new();
+    let globals_ref = &globals;
+    let helpers = GLOBALS.set(globals_ref, || Helpers::new(true));
+
+    let result = WrapFuture::new(
+        |f, cx| {
+            GLOBALS.set(globals_ref, || {
+                HANDLER.set(&handler, || HELPERS.set(&helpers, || f.poll(cx)))
+            })
+        },
+        async {
+            let mut parsed_comments = program.comments;
+            let mut program = swc_core::ecma::ast::Program::Module(program.module);
+
+            let unresolved_mark = Mark::new();
+            let top_level_mark = Mark::new();
+
+            let comments = SwcComments::default();
+            for c in parsed_comments.drain(..) {
+                comments.add_leading(c.span.lo, c);
+            }
+
+            let context = TransformContext {
+                comments: &comments,
+                source_map: &source_map,
+                top_level_mark,
+                unresolved_mark,
+                file_name_str: fs_path.file_name(),
+                file_name_hash: file_path_hash,
+            };
+
+            for transform in transforms.iter() {
+                transform.apply(&mut program, &context).await?;
+            }
+
+            Ok::<ParseResult, anyhow::Error>(ParseResult::Ok {
+                program,
+                comments,
+                //eval_context,
+                //globals: Globals::new(),
+                //source_map,
+            })
+        },
+    )
+    .await?;
+
+    /*if let ParseResult::Ok {
+        globals: ref mut g, ..
+    } = result
+    {
+        // Assign the correct globals
+        *g = globals;
+    }*/
+    Ok(result.cell())
+}
+
+#[turbo_tasks::function]
+pub async fn parse(
+    source: AssetVc,
+    transforms: EcmascriptInputTransformsVc,
+) -> Result<ParseResultVc> {
+    let content = source.content();
+    let fs_path = &*source.path().await?;
+    let fs_path_str = &*source.path().to_string().await?;
+    let file_path_hash = *hash_file_path(source.path()).await? as u128;
+
+    Ok(match &*content.await? {
+        AssetContent::Redirect { .. } => ParseResult::Unparseable.cell(),
+        AssetContent::File(file) => match &*file.await? {
+            FileContent::NotFound => ParseResult::NotFound.cell(),
+            FileContent::Content(file) => match file.content().to_str() {
+                Err(_err) => ParseResult::Unparseable.cell(),
+                Ok(string) => {
+                    let transforms = &*transforms.await?;
+
+                    parse_content(
+                        string.into_owned(),
+                        fs_path,
+                        fs_path_str,
+                        file_path_hash,
+                        source,
+                        transforms,
+                    )
+                    .await?
+                }
+            },
+        },
+    })
+}

--- a/crates/turbopack-mdx/src/transform/mod.rs
+++ b/crates/turbopack-mdx/src/transform/mod.rs
@@ -1,0 +1,13 @@
+/*
+use anyhow::Result;
+
+#[turbo_tasks::value(serialization = "auto_for_input")]
+#[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
+pub enum MdxInputTransform {
+    Default,
+}
+
+#[turbo_tasks::value(transparent, serialization = "auto_for_input")]
+#[derive(Debug, PartialOrd, Ord, Hash, Clone)]
+pub struct MdxInputTransforms(Vec<MdxInputTransform>);
+*/

--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -27,6 +27,7 @@ turbopack-css = { path = "../turbopack-css" }
 turbopack-ecmascript = { path = "../turbopack-ecmascript" }
 turbopack-env = { path = "../turbopack-env" }
 turbopack-json = { path = "../turbopack-json" }
+turbopack-mdx = { path = "../turbopack-mdx" }
 turbopack-static = { path = "../turbopack-static" }
 # turbo-tasks-rocksdb could be a dev dependencies, but optional dev dependencies are not allowed
 # turbo-tasks-rocksdb = { path = "../turbo-tasks-rocksdb", optional = true }

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -55,6 +55,7 @@ pub mod transition;
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_json::JsonModuleAssetVc;
+use turbopack_mdx::MdxModuleAssetVc;
 use turbopack_static::StaticModuleAssetVc;
 
 use self::{
@@ -200,6 +201,9 @@ async fn module(source: AssetVc, context: ModuleAssetContextVc) -> Result<AssetV
             ModuleCssModuleAssetVc::new(source, context.into(), *transforms).into()
         }
         ModuleType::Static => StaticModuleAssetVc::new(source, context.into()).into(),
+        ModuleType::Mdx(transforms) => {
+            MdxModuleAssetVc::new(source, context.into(), *transforms).into()
+        }
         ModuleType::Custom(_) => todo!(),
     })
 }
@@ -563,6 +567,7 @@ pub fn register() {
     turbopack_css::register();
     turbopack_ecmascript::register();
     turbopack_env::register();
+    turbopack_mdx::register();
     turbopack_json::register();
     turbopack_static::register();
     include!(concat!(env!("OUT_DIR"), "/register.rs"));

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -76,11 +76,24 @@ impl ModuleOptionsVc {
         };
 
         let css_transforms = CssInputTransformsVc::cell(vec![CssInputTransform::Nested]);
+        let mdx_transforms = EcmascriptInputTransformsVc::cell(
+            vec![EcmascriptInputTransform::TypeScript]
+                .iter()
+                .chain(app_transforms.await?.iter())
+                .cloned()
+                .collect(),
+        );
 
         let mut rules = vec![
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
+            ),
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Mdx(
+                    mdx_transforms,
+                ))],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".css".to_string()),

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -99,6 +99,7 @@ pub enum ModuleType {
     TypescriptDeclaration(EcmascriptInputTransformsVc),
     Json,
     Raw,
+    Mdx(EcmascriptInputTransformsVc),
     Css(CssInputTransformsVc),
     CssModule(CssInputTransformsVc),
     Static,


### PR DESCRIPTION
MdxModuleAsset is new asset type to resolve .mdx extension files. 

Since mdx is being treated as react-renderable module, it needs to follow same ecmascript transform behavior once it is parsed. To support those MdxModuleAsset borrows existing implementation from turbopack-ecmascript:

For the analyze, it converts mdx into SWC's AST and back to VirtualAssetVc, then use existing ecma analyzer. For the content, also converts mdx into SWC's AST, then apply same ecma transofmrs.